### PR TITLE
Fix issue with `getError()`

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,15 +1,10 @@
 {
   "strict": false,
-
-  "browser": true,
+  "node": true,
+  "browser": false,
   "devel": true,
   "esnext": false,
-  "jquery": true,
-  "predef": [
-    "module",
-    "require"
-  ],
-
+  "jquery": false,
   "debug": false,
   "eqeqeq": true,
   "eqnull": true,
@@ -22,7 +17,6 @@
   "singleGroups": false,
   "undef": true,
   "unused": true,
-
   "laxbreak": true,
   "laxcomma": true,
   "multistr": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -6,7 +6,7 @@
   "esnext": false,
   "jquery": true,
   "predef": [
-    "module"
+    "module",
     "require"
   ],
 

--- a/index.js
+++ b/index.js
@@ -34,12 +34,12 @@ function gulpFail(message, failAfterCompletion) {
   if (typeof getMessage !== 'function') {
     getMessage = function() {
       return (message || "Task was forced to fail.");
-    }
+    };
   }
 
   var getError = function() {
     return new PluginError(PLUGIN_NAME, gutil.colors.red(getMessage()), { showStack: false });
-  }
+  };
 
   return through.obj(function(file, _e, cb) {
     if (failAfterCompletion !== true) {
@@ -50,11 +50,11 @@ function gulpFail(message, failAfterCompletion) {
     shouldFail = true;
 
     cb(null, file);
-  }, function(_cb) {
+  }, function() {
     if (failAfterCompletion === true && shouldFail) {
       this.emit('error', getError());
     }
-  })
+  });
 }
 
 

--- a/index.js
+++ b/index.js
@@ -38,10 +38,10 @@ function gulpFail(message, failAfterCompletion) {
   }
 
   var getError = function() {
-    new PluginError(PLUGIN_NAME, gutil.colors.red(getMessage()), { showStack: false });
+    return new PluginError(PLUGIN_NAME, gutil.colors.red(getMessage()), { showStack: false });
   }
 
-  return through.obj(function(file, e, cb) {
+  return through.obj(function(file, _e, cb) {
     if (failAfterCompletion !== true) {
       cb(getError());
       return;
@@ -50,9 +50,9 @@ function gulpFail(message, failAfterCompletion) {
     shouldFail = true;
 
     cb(null, file);
-  }, function(cb) {
+  }, function(_cb) {
     if (failAfterCompletion === true && shouldFail) {
-      this.emit('error', new PluginError(PLUGIN_NAME, gutil.colors.red(getMessage()), { showStack: false }));
+      this.emit('error', getError());
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-fail",
   "description": "A gulp plugin which forces a task to fail.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "repository": "bsara/gulp-fail.git",
   "homepage": "https://github.com/bsara/gulp-fail#readme",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "jshint": "latest"
   },
   "scripts": {
-    "test": "jshint *.js test/*.js && jscs *.js test/*.js"
+    "test": "jshint *.js && jscs *.js"
   }
 }


### PR DESCRIPTION
- `getError()` now returns the instance of `PluginError`.
- Indicate unused params
- Bump patch (1.0.3)

On node v5.2, which is version I am using this plugin on, the plugin does not successfully fail, because it is passing `undefined` to the early `cb()` due to `getError()` not returning the instance of `PluginError` that it is creating. This fixes that. Also fixed a couple of other small things.
